### PR TITLE
Fixes breaking change in lodash 4

### DIFF
--- a/peak_report/src/util/builder.js
+++ b/peak_report/src/util/builder.js
@@ -6,7 +6,7 @@ export class Builder {
   }
 
   call (seriesList = []) {
-    var groupedSeries = _.groupBy(seriesList, this._shortName, this)
+    var groupedSeries = _.groupBy(seriesList, _.bind(this._shortName, this))
 
     return _.map(groupedSeries, (rowSeries, shortName) => {
       return { name: shortName, cells: this._cellsFor(rowSeries) }


### PR DESCRIPTION
Lodash has been updated in v4 of Grafana (v4 is not released yet but will be in a few weeks time) and this breaks the _.groupBy func. The thisArg argument has been removed from all functions in Lodash. See https://github.com/lodash/lodash/wiki/Changelog#v400 for details.

Fixed it by using _.bind to this instead.